### PR TITLE
Added DVTPlugInCompatibilityUUID for Xcode Version 6.4 (6E35b)

### DIFF
--- a/CocoaPodUI/CocoaPodUI-Info.plist
+++ b/CocoaPodUI/CocoaPodUI-Info.plist
@@ -24,6 +24,7 @@
 	<string>1</string>
 	<key>DVTPlugInCompatibilityUUIDs</key>
 	<array>
+		<string>7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90</string>
 		<string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string>
 		<string>8DC44374-2B35-4C57-A6FE-2AD66A36AAD9</string>
 		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>


### PR DESCRIPTION
Added DVTPlugInCompatibilityUUID for Xcode Version 6.4 (6E35b)
